### PR TITLE
Fix bug of Z close path behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+*.swp
+*.swo

--- a/src/svg/path/parser.py
+++ b/src/svg/path/parser.py
@@ -54,8 +54,9 @@ def parse_path(pathdef, current_pos=0j):
             else:
                 current_pos += pos
             
-            if start_pos is None:
-                start_pos = current_pos
+            # when M is called, reset start_pos
+            # This behavior of Z is defined in svg spec: http://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand
+            start_pos = current_pos
             
             # Implicit moveto commands are treated as lineto commands.
             # So we set command to lineto here, in case there are

--- a/src/svg/path/tests/test_parsing.py
+++ b/src/svg/path/tests/test_parsing.py
@@ -11,6 +11,14 @@ class TestParser(unittest.TestCase):
         self.assertEqual(path1, Path(Line(100+100j, 300+100j), 
                                      Line(300+100j, 200+300j),
                                      Line(200+300j, 100+100j)))
+
+        # for Z command behavior when there is multiple subpaths
+        path1 = parse_path('M 0 0 L 50 20 M 100 100 L 300 100 L 200 300 z')
+        self.assertEqual(path1, Path(
+            Line(0+0j, 50+20j),
+            Line(100+100j, 300+100j), 
+            Line(300+100j, 200+300j),
+            Line(200+300j, 100+100j)))
         
         path1 = parse_path('M 100 100 L 200 200')
         path2 = parse_path('M100 100L200 200')


### PR DESCRIPTION
SVG Spec about close path command:

The "closepath" (Z or z) ends the current subpath and causes an automatic straight line to be drawn from the current point to the initial point of the current subpath. If a "closepath" is followed immediately by a "moveto", then the "moveto" identifies the start point of the next subpath. If a "closepath" is followed immediately by any other command, then the next subpath starts at the same initial point as the current subpath.

Reference:
http://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand
