### PR TITLE
test_doc.py: don't use relative path to import doctests

### DIFF
--- a/src/svg/path/tests/test_doc.py
+++ b/src/svg/path/tests/test_doc.py
@@ -3,5 +3,5 @@ import doctest
 
 
 def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocFileSuite('../../../../README.rst'))
+    tests.addTests(doctest.DocFileSuite('README.rst', package='__main__'))
     return tests


### PR DESCRIPTION
Hi,

we've applied this patch for Debian packaging (Debian package is coming up).

Best,
Daniel Stender
