### PR TITLE
Made Path.Arc radius_check correct self.radius

### DIFF
--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -219,6 +219,7 @@ class Arc(object):
         if radius_check > 1:
             rx *= sqrt(radius_check)
             ry *= sqrt(radius_check)
+            self.radius = rx + 1j*ry
             rx_sq = rx * rx
             ry_sq = ry * ry
 


### PR DESCRIPTION
Before this change, the Arc.point() method (which uses endpoint parameterization disagreed with the center parameterization (and I believe with the specs for the how an SVG path arc should display).