### PR TITLE
Accept error kwarg in Path.point for better performance

### DIFF
--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -343,7 +343,7 @@ class Path(MutableSequence):
         self._length = sum(lengths)
         self._lengths = [each / self._length for each in lengths]
 
-    def point(self, pos):
+    def point(self, pos, error=ERROR):
 
         # Shortcuts
         if pos == 0.0:
@@ -351,7 +351,7 @@ class Path(MutableSequence):
         if pos == 1.0:
             return self._segments[-1].point(pos)
 
-        self._calc_lengths()
+        self._calc_lengths(error=error)
         # Find which segment the point we search for is located on:
         segment_start = 0
         for index, segment in enumerate(self._segments):


### PR DESCRIPTION
I found calling Path.point() calculates the length of all segments with the module's default ERROR value. These changes allow changing that value; which significantly improved performance for my use case.