### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ Changelog
 4.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use collections.abc for ABC import to add Python 3.9 compatibility.
 
 
 4.0.2 (2019-11-04)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -13,5 +13,5 @@ Steve Schwarz added an error argument to make that choice an argument.
 ClayJarCom speeded up `point()` calculations for paths.
 
 Thanks also to bug fixers Martin R, abcjjy, Daniel Stender, MTician,
-blokhin and jaraco, and thanks to tatarize for help with investigating
+blokhin, Karthikeyan and jaraco, and thanks to tatarize for help with investigating
 the subpath issues.

--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -1,7 +1,11 @@
 from __future__ import division
 from math import sqrt, cos, sin, acos, degrees, radians, log, pi
-from collections import MutableSequence
 from bisect import bisect
+
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    from collections import MutableSequence
 
 # This file contains classes for the different types of SVG path segments as
 # well as a Path object that contains a sequence of path segments.


### PR DESCRIPTION
Fixes #56 