### PR TITLE
Add smoothen_output option to d() for Path

### DIFF
--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -502,7 +502,8 @@ class Path(MutableSequence):
         self._calc_lengths(error, min_depth)
         return self._length
 
-    def d(self):
+    def d(self, smoothen_output=True):
+        # if smoothen_output is set to True, 'S' and 'T' will be used when possible
         current_pos = None
         parts = []
         previous_segment = None
@@ -525,7 +526,7 @@ class Path(MutableSequence):
             if isinstance(segment, Line):
                 parts.append("L {0:G},{1:G}".format(segment.end.real, segment.end.imag))
             elif isinstance(segment, CubicBezier):
-                if segment.is_smooth_from(previous_segment):
+                if smoothen_output and segment.is_smooth_from(previous_segment):
                     parts.append(
                         "S {0:G},{1:G} {2:G},{3:G}".format(
                             segment.control2.real,
@@ -546,7 +547,7 @@ class Path(MutableSequence):
                         )
                     )
             elif isinstance(segment, QuadraticBezier):
-                if segment.is_smooth_from(previous_segment):
+                if smoothen_output and segment.is_smooth_from(previous_segment):
                     parts.append(
                         "T {0:G},{1:G}".format(segment.end.real, segment.end.imag)
                     )


### PR DESCRIPTION
This change originated from one of my projects where I need to do manual interpolation on several SVGs. It requires corresponding paths in each file to have the same format (a.k.a. their parsed `Path` in `svg.path` should be the same except for numerical parameters) so that I could extract the parameters and do my calculations.

However, the use of `T` and `S` commands causes some trouble, as it omits some parameters in some files and my program have to take extra care (either to manually iterate over `Path`, or to revert such 'optimization'). So I add a `smoothen_output` (as optional parameter default to `True` to avoid breaking compatibility) parameter to `d()`, setting which to `False` will disable the use of these commands. Maybe this can be called a canonicalized path or something else, anyway I believe it will be helpful for some users.