### PR TITLE
Fix length calculation for quadratic beziers with colinear control points

### DIFF
--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -168,6 +168,14 @@ class QuadraticBezier(object):
         )
 
     def length(self, error=None, min_depth=None):
+        # Special case: start, control and end are colinear (ie. area of the triangle == 0)
+        cs = self.start - self.control # control to start
+        ec = self.control - self.end # end to control 
+        area = cs.real * ec.imag - ec.real * cs.imag # actually double the area of the triangle (start, control, end)
+        if area == 0.0:
+            # start, control and end are on the same line, so just add the length of the two line segments
+            return abs(cs) + abs(ec)
+        
         a = self.start - 2 * self.control + self.end
         b = 2 * (self.control - self.start)
         a_dot_b = a.real * b.real + a.imag * b.imag

--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -172,7 +172,7 @@ class QuadraticBezier(object):
         cs = self.start - self.control # control to start
         ec = self.control - self.end # end to control 
         area = cs.real * ec.imag - ec.real * cs.imag # actually double the area of the triangle (start, control, end)
-        if area == 0.0:
+        if area == 0.0 or abs(area) < 1e-10:
             # start, control and end are on the same line, so just add the length of the two line segments
             return abs(cs) + abs(ec)
         


### PR DESCRIPTION
Possible fix for #61, which seems to be caused by (some) cases of colinear control points (i.e. `start`, `control` and `end` are on one line). Not perfectly sure about then length in case the order of points on the line is `start`, `end`, `control` – as opposed to the 'standard' order `start`, `control`, `end`.