### PR TITLE
include ttf test fixture in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.rst
 include *.txt
+recursive-include src *.ttf


### PR DESCRIPTION
Thanks for `svg.path`!

Downstream on [conda-forge](https://github.com/conda-forge/svg.path-feedstock/pull/2) we try to keep the test suite running, and ran into a [missing file](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=478425&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=685). We'll grab it for CI purposes, but this PR proposes adding `.ttf` to the (at least) sdist.

Thanks again!