### PR TITLE
Refactor: Support for preserving/generating smooth curves, horizontal/vertical lines, relative commands

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,27 @@ Changelog
 - Added new abstract base classes: PathSegment, and NonLinear. Also, Linear
   is now derived from PathSegment, and may become abstract in the future.
 
+- Added smooth support:
+
+  - CubicBezier and QuadraticBezier now has a "smooth" flag, that will be set
+    when parsing if the SVG path had a smooth segment.
+
+  - A path element will now only be designated as a smooth segment if it has
+    the smooth flag set. That means a path that *is* smooth but not parsed
+    from smooth (S and T) segments will not be represented as smooth.
+    The path segment must also be smooth, so if you parse a path with a
+    smooth segment, and modify it so it isn't smooth, it will not be
+    represented as smooth, regardless of the flag.
+
+  - CubicBezier and QuadraticBezier now has a "set_smooth_from" flag, that
+    will adjust the start point and first control point so that the curve is
+    smooth. It also sets the smooth flag.
+
+- Added support to preserve vertical/horizontal commands.
+
+- Refactored the generation of SVG path texts, each segment now generates its
+  own segment text, with a `_d(self, previous)` method.
+
 
 5.1 (2022-03-23)
 ----------------

--- a/src/svg/path/tests/test_paths.py
+++ b/src/svg/path/tests/test_paths.py
@@ -289,6 +289,13 @@ class CubicBezierTest(unittest.TestCase):
         )
         self.assertTrue(segment != Line(0, 400))
 
+    def test_smooth(self):
+        cb1 = CubicBezier(0, 0, 100 + 100j, 100 + 100j)
+        cb2 = CubicBezier(600 + 500j, 600 + 350j, 900 + 650j, 900 + 500j)
+        self.assertFalse(cb2.is_smooth_from(cb1))
+        cb2.set_smooth_from(cb1)
+        self.assertTrue(cb2.is_smooth_from(cb1))
+
 
 class QuadraticBezierTest(unittest.TestCase):
     def test_svg_examples(self):
@@ -360,6 +367,13 @@ class QuadraticBezierTest(unittest.TestCase):
         self.assertAlmostEqual(p.length(), 64.57177814649368)
         p = parse_path("M 615.297 470.503 Q 538.797 694.5029999999999 538.797 694.503")
         self.assertAlmostEqual(p.length(), 236.70287281737836)
+
+    def test_smooth(self):
+        cb1 = QuadraticBezier(200 + 300j, 400 + 50j, 600 + 300j)
+        cb2 = QuadraticBezier(600 + 300j, 400 + 50j, 1000 + 300j)
+        self.assertFalse(cb2.is_smooth_from(cb1))
+        cb2.set_smooth_from(cb1)
+        self.assertTrue(cb2.is_smooth_from(cb1))
 
 
 class ArcTest(unittest.TestCase):


### PR DESCRIPTION
 - CubicBezier and QuadraticBezier now has a "smooth" flag, that will be set
   when parsing if the SVG path had a smooth segment.

 - A path element will now only be designated as a smooth segment if it has
   the smooth flag set. That means a path that *is* smooth but not parsed
   from smooth (S and T) segments will not be represented as smooth.
   The path segment must also be smooth, so if you parse a path with a
   smooth segment, and modify it so it isn't smooth, it will not be
   represented as smooth, regardless of the flag.

 - CubicBezier and QuadraticBezier now has a "set_smooth_from" flag, that
   will adjust the start point and first control point so that the curve is
   smooth. It also sets the smooth flag.

- Added support to preserve vertical/horizontal commands.

- Refactored the generation of SVG path texts, each segment now generates its
  own segment text, with a `_d(self, previous)` method.

- Now preserves if the command is relative or not