### PR TITLE
Fix: parse_path() sets .relative field of segments

### DIFF
--- a/src/svg/path/parser.py
+++ b/src/svg/path/parser.py
@@ -165,7 +165,7 @@ def parse_path(pathdef):
             pos = token[1]
             if relative:
                 pos += current_pos
-            segments.append(path.Line(current_pos, pos))
+            segments.append(path.Line(current_pos, pos, relative=relative))
             current_pos = pos
 
         elif command == "H":
@@ -173,7 +173,7 @@ def parse_path(pathdef):
             if relative:
                 hpos += current_pos.real
             pos = complex(hpos, current_pos.imag)
-            segments.append(path.Line(current_pos, pos))
+            segments.append(path.Line(current_pos, pos, relative=relative, horizontal=True))
             current_pos = pos
 
         elif command == "V":
@@ -181,7 +181,7 @@ def parse_path(pathdef):
             if relative:
                 vpos += current_pos.imag
             pos = complex(current_pos.real, vpos)
-            segments.append(path.Line(current_pos, pos))
+            segments.append(path.Line(current_pos, pos, relative=relative, vertical=True))
             current_pos = pos
 
         elif command == "C":
@@ -194,7 +194,7 @@ def parse_path(pathdef):
                 control2 += current_pos
                 end += current_pos
 
-            segments.append(path.CubicBezier(current_pos, control1, control2, end))
+            segments.append(path.CubicBezier(current_pos, control1, control2, end, relative=relative))
             current_pos = end
 
         elif command == "S":
@@ -219,7 +219,7 @@ def parse_path(pathdef):
                 control1 = current_pos
 
             segments.append(
-                path.CubicBezier(current_pos, control1, control2, end, smooth=True)
+                path.CubicBezier(current_pos, control1, control2, end, relative=relative, smooth=True)
             )
             current_pos = end
 
@@ -231,7 +231,7 @@ def parse_path(pathdef):
                 control += current_pos
                 end += current_pos
 
-            segments.append(path.QuadraticBezier(current_pos, control, end))
+            segments.append(path.QuadraticBezier(current_pos, control, end, relative=relative))
             current_pos = end
 
         elif command == "T":
@@ -254,7 +254,7 @@ def parse_path(pathdef):
                 control = current_pos
 
             segments.append(
-                path.QuadraticBezier(current_pos, control, end, smooth=True)
+                path.QuadraticBezier(current_pos, control, end, smooth=True, relative=relative)
             )
             current_pos = end
 
@@ -270,7 +270,7 @@ def parse_path(pathdef):
             if relative:
                 end += current_pos
 
-            segments.append(path.Arc(current_pos, radius, rotation, arc, sweep, end))
+            segments.append(path.Arc(current_pos, radius, rotation, arc, sweep, end, relative=relative))
             current_pos = end
 
         # Finish up the loop in preparation for next command


### PR DESCRIPTION
Hi!

I'm checking your lib to potentially includes it in [fpdf2](https://github.com/PyFPDF/fpdf2).

I spotted this minor problem that prevents proper parsing of lowercase SVG commands.