### PR TITLE
Fix serialization of 'H'/'h' command

### DIFF
--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -118,7 +118,7 @@ class Line(Linear):
 
         if self.horizontal and self.is_horizontal_from(previous):
             cmd = "h" if self.relative else "H"
-            return f"{cmd} {x:G},{y:G}"
+            return f"{cmd} {x:G}"
 
         if self.vertical and self.is_vertical_from(previous):
             cmd = "v" if self.relative else "V"


### PR DESCRIPTION
Hello, I found following path which is not properly serialized and cannot be displayed in Chrome. The reason was that the browser doesn't understand H/h command with two arguments. So I made this pull request.

```
M 20.3715,29.164 v 41.6719 h 23.7228 l 35.513,29.164 l 0.0211104,-100 l -35.5183,29.164 H 20.3715 z
```