### PR TITLE
Prevent installation of tests through setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include *.txt
 
 recursive-include src *.png
 
+global-exclude tests/*

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
-setup()
+setup(packages=find_packages("src", exclude=["*tests"]))


### PR DESCRIPTION
Currently when the package is built and installed into the system using the python3 setup.py/python3 setup.py install flow, it also installs the tests. There's no real reason the tests should be distributed with the rest of the code. This patch prevents the tests from being installed in this manner.