### PR TITLE
Add _BaseSegment to simplify type annotations.

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -649,10 +649,28 @@ class TestPath(unittest.TestCase):
         del path2[-1]
         self.assertFalse(path1 == path2)
 
+        # Get rid of the last segment using a slice:
+        del path1[-1:]
+        self.assertTrue(path1 == path2)
+
         # It's not equal to a list of it's segments
-        # TODO: Path does not support slicing, but this is not tested here.
-        self.assertTrue(path1 != path1[:])  # type: ignore[index]
-        self.assertFalse(path1 == path1[:])  # type: ignore[index]
+        self.assertTrue(path1 != path1[:])
+        self.assertFalse(path1 == path1[:])
+
+        # A slice of a Path is not a Path. It is a list of segment:
+        self.assertTrue(isinstance(path1[1:2], list))
+        self.assertFalse(isinstance(path1[1:2], Path))
+
+        # Test setting a single item:
+        path1[1] = path2[2]
+        self.assertFalse(path1 == path2)
+        path1[1] = path2[1]
+        self.assertTrue(path1 == path2)
+        # Test setting a slice of items:
+        path1[1:2] = path2[1:3]
+        self.assertFalse(path1 == path2)
+        path1[1:3] = path2[1:2]
+        self.assertTrue(path1 == path2)
 
     def test_non_arc(self) -> None:
         # And arc with the same start and end is a noop.


### PR DESCRIPTION
_BaseSegment is a private type alias for either PathSegment or Move classes.

It simplifies the type annotations and resolves most of the typing issue.

This commit also fixes the typing issues for slices (as in __getitem__).

Adding typing for slices make the behaviour of the Path class a bit more official.
Path behaves here a bit differently from most mutable sequences.
For example, a slice of an array is an array:
```
>>> from array import array
>>> a = array("i", [1, 2, 3])
>>> a[1:2]
array('i', [2])
```

Therefore it would make sense that a slice of a Path would also be a Path
and not a list.

We could make any usage of slice raise a NotImplementedError.
It would brake backward compatibility, but I would be surprised if anyone
is using slices of Path.

The other option is to apply this PR as is.