### PR TITLE
Expose lengths in the Path class

### DIFF
--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -928,6 +928,17 @@ class Path(PathType):
             return NotImplemented
         return not self == other
 
+    @property
+    def lengths(self) -> List[float]:
+        """The relative lengths of each segment in the path.
+
+        The sum of all lengths is 1.0, unless the path has zero length, in
+        which case all lengths are zero.
+        """
+        self._calc_lengths()
+        assert self._lengths is not None
+        return self._lengths
+
     def _calc_lengths(self, error: float = ERROR, min_depth: int = MIN_DEPTH) -> None:
         if self._length is not None:
             return

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -63,6 +63,23 @@ class PathTest(unittest.TestCase):
         with pytest.raises(TypeError):
             path[1] = [Line(start=0j, end=(20 + 20j))]  # type: ignore
 
+    def test_path_lengths(self) -> None:
+        path = parse_path("M 0 0 L 100 0 L 100 50 L 0 50 z")
+        self.assertAlmostEqual(path.length(), 300.0)
+        self.assertEqual(len(path), 5)
+
+        lengths = path.lengths
+        self.assertEqual(len(lengths), 5)
+        expected = [
+            0.0,
+            0.3333333333333333,
+            0.16666666666666666,
+            0.3333333333333333,
+            0.16666666666666666,
+        ]
+        for a, b in zip(lengths, expected):
+            self.assertAlmostEqual(a, b)
+
 
 # Most of these test points are not calculated separately, as that would
 # take too long and be too error prone. Instead the curves have been verified


### PR DESCRIPTION
In order to properly render a complex `Path`, you need to know where the boundaries between each segments are in `[0, 1]`. Expose the lengths as a property of the `Path` class.