### PR TITLE
Reset cached segment fractions when a Path is re-measured

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,11 @@ Changelog
 
 - Better handling of tangents of paths that start with a Move()
 
+- Reset the cached segment fractions when a Path is re-measured, so that
+  mutating a Path (via del/setitem/insert/slice assignment) and calling
+  point()/tangent() again returns correct results instead of wrong
+  coordinates or an IndexError.
+
 
 7.0 (2025-07-06)
 ----------------

--- a/src/svg/path/path.py
+++ b/src/svg/path/path.py
@@ -940,7 +940,11 @@ class Path(PathType):
             self._lengths = lengths
         else:
             self._lengths = [each / self._length for each in lengths]
-        # Calculate the fractional distance for each segment to use in point()
+        # Calculate the fractional distance for each segment to use in point().
+        # Reset first: mutating the path only clears self._length, so a stale
+        # self._fractions from an earlier calculation would otherwise be
+        # appended to here, corrupting the segment lookup in _find_segment().
+        self._fractions = []
         fraction = 0.0
         for each in self._lengths:
             fraction += each

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -63,6 +63,34 @@ class PathTest(unittest.TestCase):
         with pytest.raises(TypeError):
             path[1] = [Line(start=0j, end=(20 + 20j))]  # type: ignore
 
+    def test_measure_then_mutate_then_measure(self) -> None:
+        # Measuring a path caches per-segment fractional distances. Mutating
+        # the path (Path is a MutableSequence) must invalidate that cache so a
+        # subsequent measurement recomputes it correctly. Previously only the
+        # cached total length was cleared while the fractions list kept being
+        # appended to, so the second measurement corrupted the segment lookup.
+        square = "M 0,0 L 10,0 L 10,10 L 0,10 Z"
+
+        for mutate in (
+            lambda p: p.__setitem__(1, Line(0j, 20 + 0j)),
+            lambda p: p.__delitem__(1),
+            lambda p: p.insert(1, Line(0j, 5 + 0j)),
+            lambda p: p.__setitem__(slice(1, 2), parse_path("M 0,0 L 5,0")),
+        ):
+            path = parse_path(square)
+            path.length()  # first measurement primes the caches
+            mutate(path)
+            path.length()  # second measurement must rebuild, not append
+
+            # The fractions cache must have exactly one entry per segment.
+            self.assertEqual(len(path._fractions), len(path))
+
+            # point() must agree with an identical, never-mutated path and must
+            # not raise IndexError from an over-long fractions list.
+            clean = Path(*list(path))
+            for pos in (0.0, 0.25, 0.5, 0.75, 1.0):
+                self.assertAlmostEqual(path.point(pos), clean.point(pos))
+
 
 # Most of these test points are not calculated separately, as that would
 # take too long and be too error prone. Instead the curves have been verified


### PR DESCRIPTION
### Problem

`Path` is a `MutableSequence`, and the natural measure → edit → measure workflow
returns wrong coordinates or crashes:

```python
from svg.path import parse_path
p = parse_path("M0,0 L10,0 L10,10 L0,10")
p.length()
del p[1]
p.length()
p.point(0.5)        # (5+10j) - wrong; an identical never-mutated path gives (10+10j)
```

Mutating a `Path` (via `del`/`__setitem__`/`insert`/slice assignment)
invalidates the cached length by setting `self._length = None`, but leaves
`self._fractions` populated. `_calc_lengths()` appends to `self._fractions`
without clearing it first, so a second measurement builds a list of twice the
segment count. `_find_segment()` then bisects this corrupt, non-monotonic list
and indexes `self._segments` out of range — returning wrong coordinates from
`point()`/`tangent()`, or raising `IndexError` for the setitem/insert/slice
cases.

### Fix

Reset `self._fractions` before the append loop in `_calc_lengths()` so a
re-measure rebuilds it from scratch.

### Tests

`test_measure_then_mutate_then_measure` exercises all four mutators, asserting
`len(_fractions) == len(path)` and that `point()` at several parameters matches
an identical never-mutated `Path`, with no `IndexError`.

Full suite: 54 passed, 1 skipped. `black --check` / `flake8` clean.
